### PR TITLE
explicitly set earlyBootSet

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
+    autoImport: {
+      earlyBootSet: () => [],
+    },
     'ember-bootstrap': {
       bootstrapVersion: 5,
       importBootstrapCSS: true,


### PR DESCRIPTION
This PR demonstrate that the regression is caused `earlyBootSet` option introduced with `ember-auto-import@2.6.0`. Opting out of that new behavior by returning an empty array fixes the build.