### PR TITLE
extend default early boot set by @ember/-internals/metal

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,17 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
+    autoImport: {
+      earlyBootSet: () => [
+        '@glimmer/tracking',
+        '@glimmer/component',
+        '@ember/service',
+        '@ember/controller',
+        '@ember/routing/route',
+        '@ember/component',
+        '@ember/-internals/metal',
+      ],
+    },
     'ember-bootstrap': {
       bootstrapVersion: 5,
       importBootstrapCSS: true,


### PR DESCRIPTION
This PR demonstrate that adding `@ember/-internals/metal` to the default early boot set defined in https://github.com/ef4/ember-auto-import/blob/29eab602ff01d2c89b0140a0c2c0e534ad7d5b41/packages/ember-auto-import/ts/webpack.ts#L50-L57 does _not_ resolve the issue.